### PR TITLE
use older version of numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # icon-vis
 
-[![Build Status](https://jenkins-mch.cscs.ch/job/iconvis_testsuite/badge/icon?config=build)](https://jenkins-mch.cscs.ch/job/iconvis_testsuite/)
-[![Build Status](https://jenkins-mch.cscs.ch/job/iconvis_testsuite/badge/icon?config=test)](https://jenkins-mch.cscs.ch/job/iconvis_testsuite/)
+[![Build Status](https://jenkins-mch.cscs.ch/job/iconvis_testsuite/badge/icon?config=build)](https://jenkins-mch.cscs.ch/job/IconVis/job/iconvis_testsuite/)
+[![Build Status](https://jenkins-mch.cscs.ch/job/iconvis_testsuite/badge/icon?config=test)](https://jenkins-mch.cscs.ch/job/IconVis/job/iconvis_testsuite/)
 
 ## Introduction
 This repo is a collection of python scripts to visualise ICON-simulations on the unstructered grid. The different folders contain example code for various types of plots. Example datasets for testing can be downloaded following the instructions in the [data](https://github.com/C2SM/icon-vis/tree/master/data) folder. Example plots for each folder are shown below. More detailed descriptions for each plot are in the README files of the different folders. The routines are mainly based on the python library  [psyplot](https://psyplot.github.io). The [C2SM/iconarray](https://github.com/C2SM/iconarray) python package was developed together with icon-vis, to contain the modules used in this repository.

--- a/env/environment.yml
+++ b/env/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - psy-maps
 - cartopy
 - psy-view
-- numpy
+- numpy<1.24
 - matplotlib[version='<3.5']
 - geos
 - proj


### PR DESCRIPTION
A newer version of an unknown package seems to be incompatible with the newest numpy version as it deprecated the attribute 'typeDict'. Using a numpy version older than 1.24 seems to solve this issue.