### PR TITLE
Refactor setup-conda-env.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,15 @@ Create psyplot-kernel:
 
     kernel-create -n psyplot-kernel
 
-It may be necessary to add a CONDA_PREFIX to the launcher file to work with cartopy. Therefore open your psyplot-kernel launcher file:
+It may be necessary to export the CONDA_PREFIX, the GRIB_DEFINITION_PATH and the FIELDEXTRA_PATH in the launcher file. Therefore, open your psyplot-kernel launcher file:
 	
 	vim $HOME/.local/share/jupyter/kernels/psyplot-kernel/launcher
 	
-and add the following line after the first line: 
+and add the following lines after the first line (make sure the CONDA_PREFIX points to where YOUR conda environment is located): 
 	
 	export CONDA_PREFIX=$SCRATCH/miniconda3/envs/psyplot
+	export GRIB_DEFINITION_PATH=$SCRATCH/miniconda3/envs/psyplot/share/eccodes-cosmo-resources/definitions/:$SCRATCH/miniconda3/envs/psyplot/share/eccodes/definitions/
+	export FIELDEXTRA_PATH=/project/s83c/fieldextra/daint/bin/fieldextra_gnu_opt_omp
 
 You can now start JupyterLab with https://jupyter.cscs.ch and open the _psyplot-kernel_ notebook.
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ If you have specific question about plotting, you can write that into the discus
 
 	> __init__() got an unexpected keyword argument 'capture_output'
 
-	Check for outdated spack commands in your $HOME/.bashrc (should align with instructione in [C2SM spack Documentation](https://c2sm.github.io/spack-c2sm/Install.html#automatically-source-preinstalled-spack-instance), and if using VS Code/Remote-SSH you might also need to uncheck **Remote.SSH: Use Local Server** in your VS Code Remote-SSH settings, to force a new connection upon reconnecting.
+	Check for outdated spack commands in your $HOME/.bashrc (should align with instruction in [C2SM spack Documentation](https://c2sm.github.io/spack-c2sm/Install.html#automatically-source-preinstalled-spack-instance), and if using VS Code/Remote-SSH you might also need to uncheck **Remote.SSH: Use Local Server** in your VS Code Remote-SSH settings, to force a new connection upon reconnecting.
 
 2. Value error on `psy.open_dataset(f_grib2, engine="cfgrib", ...)`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you already have the environment but want to update it:
 
     conda env update --file env/environment.yml --prune
 
-If you are using the conda setup and want to use GRIB data, you will need to set the ```GRIB_DEFINITION_PATH```. This can be done on Tsa/Daint by sourcing the script ```setup-conda-env.sh```. It only needs to be run a single time, as it will save the ```GRIB_DEFINITION_PATH``` environment variable to the conda environment. You will need to deactivate and reactivate the conda environment after doing this. You can check it has been correctly set by ``` conda env config vars list```. This script also sets the Fieldextra path, which is used for data interpolation. See [FAQs](#trouble-shooting) if you get an error running this.
+If you are using the conda setup and want to use GRIB data, you will need to set the ```GRIB_DEFINITION_PATH```. This can be done on Tsa/Daint by sourcing the script ```setup-conda-env.sh```. It only needs to be run a single time, as it will save the ```GRIB_DEFINITION_PATH``` environment variable to the conda environment. You will need to deactivate and reactivate the conda environment after doing this. You can check it has been correctly set by ```conda env config vars list```. This script also sets the Fieldextra path, which is used for data interpolation. See [FAQs](#trouble-shooting) if you get an error running this.
 
     source env/setup-conda-env.sh
 

--- a/env/environment.yml
+++ b/env/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - git=2.34.1
 - pip
 - cfgrib>=0.9.9.1
-- eccodes=2.24.2
+- eccodes=2.25.0
 - psy-reg
 - psy-maps
 - cartopy

--- a/env/setup-conda-env.sh
+++ b/env/setup-conda-env.sh
@@ -1,48 +1,97 @@
 #!/bin/bash
 
-if [[ $HOST == *'tsa'* ]]; then
-    echo 'Setting GRIB_DEFINITION_PATH for cfgrib engine'
-    module load python
-    source /project/g110/spack/user/admin-tsa/spack/share/spack/setup-env.sh
+function check_python {
+    python_version_l=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
+    python_version_maj=$(python -c 'import sys; print(".".join(map(str, sys.version_info[0:1])))')
+    python_version_min=$(python -c 'import sys; print(".".join(map(str, sys.version_info[1:2])))')
+    python_lib=$(python --version | tr '[:upper:]' '[:lower:]' | sed 's/ //g' | sed 's/\.[^.]*$//')
 
-    cosmo_eccodes=`spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1`
-    eccodes=`spack find --format "{prefix}" eccodes@2.19.0%gcc ~aec | head -n1`
-    export GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/
+    min_required_maj=3
+    min_required_min=9
+    if [[ $(echo $python_version_maj'>='$min_required_maj | bc -l) == 1  ]]  && [[ $(echo $python_version_min'>='$min_required_min | bc -l) == 1  ]] ; then
+        echo "Python version: $python_version_l"
+    else
+        echo -e "\e[31mPython version: $python_version_l\e[0m"
+        echo -e "\e[31mPlease check your Python version >= 3.9 and make sure that the appropriate Conda env is activated.\e[0m"
+        exit $1
+    fi
+    if [[ -d "$CONDA_PREFIX/lib/$python_lib" ]]; then
+        echo "Found $python_lib within Conda environment."
+    else
+        echo -e "\e[31mPlease check your Python binary path and make sure that the appropriate Conda environment is activated.\e[0m"
+        exit $1
+    fi
+}
+
+function set_grib_definition_path {
+
+    basedir=$PWD
+    cosmo_eccodes=$CONDA_PREFIX/share/eccodes-cosmo-resources
+    git clone --depth 1 --branch v2.25.0.1 https://github.com/COSMO-ORG/eccodes-cosmo-resources.git $cosmo_eccodes
+
+    if [[ -d "$cosmo_eccodes/definitions" ]]; then
+        echo 'Cosmo-eccodes-definitions were successfully retrieved.'
+    else
+        echo -e "\e[31mCosmo-eccodes-definitions could not be cloned.\e[0m"
+        exit $1
+    fi
+
+    eccodes=$CONDA_PREFIX/share/eccodes
+
+    if [[ -d "$eccodes/definitions" ]]; then
+        echo 'Eccodes definitions were successfully retrieved.'
+    else
+        echo -e "\e[31mEccodes retrieval failed. \e[0m"
+        exit $1
+    fi
+
+    export GRIB_DEFINITION_PATH=${cosmo_eccodes}/definitions/:${eccodes}/definitions/
     export OMPI_MCA_pml="ucx"
     export OMPI_MCA_osc="ucx"
-    echo 'GRIB_DEFINITION_PATH: '${GRIB_DEFINITION_PATH}
-    conda env config vars set GRIB_DEFINITION_PATH=${GRIB_DEFINITION_PATH}
-elif [[ $HOST == *'daint'* ]]; then
-    echo 'Setting GRIB_DEFINITION_PATH for cfgrib engine'
-    module load cray-python
-    source /project/g110/spack/user/admin-daint/spack/share/spack/setup-env.sh
+    conda env config vars set GRIB_DEFINITION_PATH=${cosmo_eccodes}/definitions/:${eccodes}/definitions/
+}
 
-    cosmo_eccodes=`spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1`
-    eccodes=`spack find --format "{prefix}" eccodes@2.19.0%gcc ~aec | head -n1`
-    export GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/
-    export OMPI_MCA_pml="ucx"
-    export OMPI_MCA_osc="ucx"
-    echo 'GRIB_DEFINITION_PATH: ' ${GRIB_DEFINITION_PATH}
-    conda env config vars set GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/
-fi
+
+check_python
+set_grib_definition_path
 
 # ---- required for fieldextra ------
 
-if [[ $HOST == *'tsa'* ]]; then
+if [[ $(hostname -s) == *'tsa'* ]]; then
 
     echo 'Setting FIELDEXTRA_PATH for tsa'
     conda env config vars set FIELDEXTRA_PATH=/project/s83c/fieldextra/tsa/bin/fieldextra_gnu_opt_omp
 
-elif [[ $HOST == *'daint'* ]]; then
+elif [[ $(hostname -s) == *'daint'* ]]; then
 
     echo 'Setting FIELDEXTRA_PATH for daint'
     conda env config vars set FIELDEXTRA_PATH=/project/s83c/fieldextra/daint/bin/fieldextra_gnu_opt_omp
 
+elif [[ $(hostname -s) == *'nid'* ]]; then
+
+    echo 'Setting FIELDEXTRA_PATH for balfrin'
+    conda env config vars set FIELDEXTRA_PATH=/users/oprusers/osm/bin/fieldextra
 fi
 
 # ---- required for cartopy ------
 
-echo 'Make sure to deactivate your environment completely before reactivating (i.e., you should not be in a base environment). To make sure, you can run conda deactivate twice'
-echo 'Enable cartopy to modify cartopy.config by placing siteconfig.py in cartopy package'
-vpython=$(ls --color=never -d $CONDA_PREFIX/lib/python*);
-cp env/siteconfig.py ${vpython}/site-packages/cartopy
+if cp env/siteconfig.py $CONDA_PREFIX/lib/$python_lib/site-packages/cartopy; then
+    echo 'Cartopy configuration completed successfully.'
+else
+    echo -e "\e[31mEnable cartopy to modify cartopy.config by placing the env/siteconfig.py file into cartopy package source folder.\n\e[0m"\
+        "\e[31mPlease make sure that you are in the parent directory of the iconarray folder while executing this setup script.\e[0m"
+    exit $1
+fi
+
+echo -e "\n "\
+ "Variables saved to environment: \n "\
+ " "
+
+conda env config vars list
+
+echo -e "\n "\
+    "\e[32mThe setup script completed successfully! \n \e[0m" \
+    "\e[32mMake sure to deactivate your environment completely before reactivating it by running conda deactivate twice: \n \e[0m" \
+    "\n "\
+    "\e[32m            conda deactivate  \n \e[0m"\
+    " "


### PR DESCRIPTION
As in iconarray https://github.com/C2SM/iconarray/pull/46, setup-conda-env.sh refactored, having removed dependency on spack. cosmo-definitions are cloned directly from github and eccodes definitions are taken from conda installation of eccodes.
