### PR TITLE
Restrict xarray to older version

### DIFF
--- a/env/environment.yml
+++ b/env/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - matplotlib[version='<3.5']
 - geos
 - proj
-- xarray[version='<2022.6.0']
+- xarray[version='<2022.06.0']
 - jupyter
 - ipympl
 - cmcrameri

--- a/testsuite/Jenkinsfile
+++ b/testsuite/Jenkinsfile
@@ -27,7 +27,6 @@ pipeline {
                         script {
                             BuildBadge.setStatus('running')
                         }
-                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/setup.sh'
                     }
                     post {
@@ -46,7 +45,6 @@ pipeline {
                         script {
                             BuildBadge.setStatus('running')
                         }
-                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/setup.sh'
                     }
                     post {
@@ -85,7 +83,6 @@ pipeline {
                         script {
                             TestBadge.setStatus('running')
                         }
-                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/test.sh'
                     }
                     post {
@@ -122,7 +119,6 @@ pipeline {
                         script {
                             TestBadge.setStatus('running')
                         }
-                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/test.sh'
                     }
                     post {

--- a/testsuite/Jenkinsfile
+++ b/testsuite/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
                         script {
                             BuildBadge.setStatus('running')
                         }
+                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/setup.sh'
                     }
                     post {
@@ -45,6 +46,7 @@ pipeline {
                         script {
                             BuildBadge.setStatus('running')
                         }
+                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/setup.sh'
                     }
                     post {
@@ -83,6 +85,7 @@ pipeline {
                         script {
                             TestBadge.setStatus('running')
                         }
+                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/test.sh'
                     }
                     post {
@@ -119,6 +122,7 @@ pipeline {
                         script {
                             TestBadge.setStatus('running')
                         }
+                        export PYTHONNOUSERSITE=True
                         sh 'testsuite/test.sh'
                     }
                     post {

--- a/testsuite/setup.sh
+++ b/testsuite/setup.sh
@@ -9,6 +9,7 @@ source $WORKSPACE/miniconda_${NODE_NAME}/etc/profile.d/conda.sh
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
 conda config --set channel_priority strict
+export PYTHONNOUSERSITE=True
 conda env create --name ${CONDA_ENV_NAME}_${NODE_NAME} --file env/environment.yml
 
 conda activate ${CONDA_ENV_NAME}_${NODE_NAME}

--- a/testsuite/setup.sh
+++ b/testsuite/setup.sh
@@ -8,6 +8,7 @@ source $WORKSPACE/miniconda_${NODE_NAME}/etc/profile.d/conda.sh
 
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 conda env create --name ${CONDA_ENV_NAME}_${NODE_NAME} --file env/environment.yml
 
 conda activate ${CONDA_ENV_NAME}_${NODE_NAME}

--- a/testsuite/test.sh
+++ b/testsuite/test.sh
@@ -6,5 +6,6 @@ source $WORKSPACE/miniconda_${NODE_NAME}/etc/profile.d/conda.sh
 conda activate ${CONDA_ENV_NAME}_${NODE_NAME}
 python -m cfgrib selfcheck
 python -c "import cartopy; print(cartopy.config)"
+python -c "import xarray; print('The version of xarray is:', xarray.__version__)"
 
 pytest testsuite/test*.py

--- a/testsuite/test.sh
+++ b/testsuite/test.sh
@@ -4,6 +4,7 @@
 
 source $WORKSPACE/miniconda_${NODE_NAME}/etc/profile.d/conda.sh
 conda activate ${CONDA_ENV_NAME}_${NODE_NAME}
+export PYTHONNOUSERSITE=True
 python -m cfgrib selfcheck
 python -c "import cartopy; print(cartopy.config)"
 python -c "import xarray; print('The version of xarray is:', xarray.__version__)"

--- a/testsuite/test.sh
+++ b/testsuite/test.sh
@@ -7,6 +7,5 @@ conda activate ${CONDA_ENV_NAME}_${NODE_NAME}
 export PYTHONNOUSERSITE=True
 python -m cfgrib selfcheck
 python -c "import cartopy; print(cartopy.config)"
-python -c "import xarray; print('The version of xarray is:', xarray.__version__)"
 
 pytest testsuite/test*.py


### PR DESCRIPTION
Add `export PYTHONNOUSERSITE=True` to make sure that the conda environment does not use packages accidentally installed on Jenkins home.

Because of an ongoing issue in psy-transect (https://github.com/psyplot/psy-transect/issues/1), xarray needs to be restricted to a version <2022.06.0. There was I typo in the already implemented restriction.